### PR TITLE
Add gallery access button and test image area

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,6 +13,7 @@ import Animated, {
   LinearTransition,
 } from "react-native-reanimated";
 import CameraTools from "@/components/CameraTools";
+import GalleryButton from "@/components/GalleryButton";
 
 export default function HomeScreen() {
   const cameraRef = React.useRef<CameraView>(null);
@@ -66,6 +67,8 @@ export default function HomeScreen() {
             }
             cameraMode={cameraMode}
           />
+          {/* Access the gallery from the bottom left */}
+          <GalleryButton />
         </View>
       </SafeAreaView>
     </Animated.View>

--- a/app/media-library.tsx
+++ b/app/media-library.tsx
@@ -5,6 +5,12 @@ import { Button, ScrollView } from "react-native";
 import { Asset, getAlbumsAsync, getAssetsAsync } from "expo-media-library";
 import { Image } from "expo-image";
 
+// Test images can be added to this array for quick gallery testing
+// Example: require("../assets/images/react-logo.png")
+const testImages = [
+  // Add local images here
+];
+
 export default function MediaLibrary() {
   const [assets, setAssets] = React.useState<Asset[]>([]);
 
@@ -47,6 +53,14 @@ export default function MediaLibrary() {
             ),
           }}
         />
+        {/* Display any test images added above */}
+        {testImages.map((img, index) => (
+          <Image
+            key={`test-${index}`}
+            source={img}
+            style={{ width: "25%", height: 100 }}
+          />
+        ))}
         {assets.map((photo) => (
           <Image
             key={photo.id}

--- a/components/GalleryButton.tsx
+++ b/components/GalleryButton.tsx
@@ -1,0 +1,15 @@
+import { Link } from "expo-router";
+import IconButton from "./IconButton";
+
+export default function GalleryButton() {
+  return (
+    <Link href="/media-library" asChild>
+      {/* Small button positioned in the bottom left to open the gallery */}
+      <IconButton
+        iosName="photo.on.rectangle"
+        androidName="images-outline"
+        containerStyle={{ position: "absolute", bottom: 10, left: 10 }}
+      />
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- add a `GalleryButton` component to open the gallery
- show the button on the camera screen
- add placeholder array in the media library screen so images can be added for testing

## Testing
- `npm test` *(fails: Cannot find module '@babel/helper-globals/data/builtin-lower.json')*
- `npm run lint` *(fails: fetch failed due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_686712b92b308329bd67a151bb41a673