### PR TITLE
Add gallery selection and rename app

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">snapchat-clone</string>
+  <string name="app_name">RecyCam-Demo-Release</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">automatic</string>

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -31,7 +31,7 @@ extensions.configure(com.facebook.react.ReactSettingsExtension) { ex ->
 }
 expoAutolinking.useExpoModules()
 
-rootProject.name = 'snapchat-clone'
+rootProject.name = 'RecyCam-Demo-Release'
 
 expoAutolinking.useExpoVersionCatalog()
 

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "snapchat-clone",
-    "slug": "snapchat-clone",
+    "name": "RecyCam-Demo-Release",
+    "slug": "recycam-demo-release",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -14,6 +14,7 @@ import Animated, {
 } from "react-native-reanimated";
 import CameraTools from "@/components/CameraTools";
 import GalleryButton from "@/components/GalleryButton";
+import { useLocalSearchParams, useRouter } from "expo-router";
 
 export default function HomeScreen() {
   const cameraRef = React.useRef<CameraView>(null);
@@ -24,6 +25,15 @@ export default function HomeScreen() {
   const [cameraZoom, setCameraZoom] = React.useState<number>(0);
   const [picture, setPicture] = React.useState<string>("");
   const [isBrowsing, setIsBrowsing] = React.useState<boolean>(false);
+  const router = useRouter();
+  const params = useLocalSearchParams<{ selected?: string }>();
+
+  React.useEffect(() => {
+    if (params.selected && typeof params.selected === "string") {
+      setPicture(params.selected);
+      router.setParams({ selected: undefined });
+    }
+  }, [params.selected]);
 
   async function handleTakePicture() {
     const response = await cameraRef.current?.takePictureAsync({});

--- a/app/media-library.tsx
+++ b/app/media-library.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { Link, Stack } from "expo-router";
-import { Button, ScrollView } from "react-native";
+import { Link, Stack, router } from "expo-router";
+import { Button, ScrollView, Pressable } from "react-native";
 
 import { Asset, getAlbumsAsync, getAssetsAsync } from "expo-media-library";
 import { Image } from "expo-image";
@@ -25,7 +25,7 @@ export default function MediaLibrary() {
 
     // Recents album
     const albumAssets = await getAssetsAsync({
-      album: fetchedAlbums.find((album) => album.title === "Recentsd"),
+      album: fetchedAlbums.find((album) => album.title === "Recents"),
       mediaType: "photo",
       sortBy: "creationTime",
     });
@@ -55,21 +55,27 @@ export default function MediaLibrary() {
         />
         {/* Display any test images added above */}
         {testImages.map((img, index) => (
-          <Image
+          <Pressable
             key={`test-${index}`}
-            source={img}
-            style={{ width: "25%", height: 100 }}
-          />
+            onPress={() =>
+              router.replace({ pathname: "/", params: { selected: img } })
+            }
+          >
+            <Image source={img} style={{ width: "25%", height: 100 }} />
+          </Pressable>
         ))}
         {assets.map((photo) => (
-          <Image
+          <Pressable
             key={photo.id}
-            source={photo.uri}
-            style={{
-              width: "25%",
-              height: 100,
-            }}
-          />
+            onPress={() =>
+              router.replace({ pathname: "/", params: { selected: photo.uri } })
+            }
+          >
+            <Image
+              source={photo.uri}
+              style={{ width: "25%", height: 100 }}
+            />
+          </Pressable>
         ))}
       </ScrollView>
     </>

--- a/ios/snapchatclone/Info.plist
+++ b/ios/snapchatclone/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleDevelopmentRegion</key>
     <string>$(DEVELOPMENT_LANGUAGE)</string>
     <key>CFBundleDisplayName</key>
-    <string>snapchat-clone</string>
+    <string>RecyCam-Demo-Release</string>
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleIdentifier</key>


### PR DESCRIPTION
## Summary
- let users choose a photo from the media library
- auto-display the chosen image just like a captured picture
- rename the app to **RecyCam-Demo-Release** across config files

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672718888c8329a8f41dcb1313f264