### PR TITLE
Fix gallery permissions and asset loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,6 @@ const response = await fetch("http://<your-ip>:5000/predict", {
 
 - On first launch you will be asked for camera, microphone and media library permissions—grant them so the demo can operate.
 - Press the camera button to capture a photo. After taking a picture you can upload it to the backend and view the predicted label.
+- Tap the gallery button to browse and select any photo on your device. You will be prompted for photo access permission if it hasn't been granted.
 
 Enjoy exploring this early version of **RecyCam**!


### PR DESCRIPTION
## Summary
- improve gallery permission handling and fetch all photos
- document gallery usage in README

## Testing
- `npm test` *(fails: `jest: not found`)*
- `npm run lint` *(fails: `expo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686736808b3883298544c1288f5df174